### PR TITLE
FIX fr translation

### DIFF
--- a/fr/errors.po
+++ b/fr/errors.po
@@ -20,11 +20,11 @@ msgstr "est invalide"
 
 ## From Ecto.Changeset.validate_format/3
 msgid "has invalid format"
-msgstr "à un format invalide"
+msgstr "a un format invalide"
 
 ## From Ecto.Changeset.validate_subset/3
 msgid "has an invalid entry"
-msgstr "à une entrée invalide"
+msgstr "a une entrée invalide"
 
 ## From Ecto.Changeset.validate_exclusion/3
 msgid "is reserved"
@@ -87,4 +87,3 @@ msgstr "doit être plus grand ou égal à %{number}"
 
 msgid "must be equal to %{number}"
 msgstr "doit être égal à %{number}"<% end %>
-


### PR DESCRIPTION
There is a typo in french translation:
"à un format invalide" would translate to something like "to an invalid
format" and not "has invalid format".